### PR TITLE
Arranger le thème Pavillon E

### DIFF
--- a/changeTheme.js
+++ b/changeTheme.js
@@ -1,20 +1,20 @@
 chrome.storage.sync.get('theme', function (arg) {
     if (arg.theme === 'pavillon-e-theme') {
         injectCSS( /*css*/ `
-        body, html, #etsBellowHeader {
-            background-image: url(${chrome.runtime.getURL('assets/pavillonE.jpg')}), linear-gradient(to bottom, white, white)!important;
-           }
-           
-           #etsHeaderContainer{
-               background-color:#262626!important;
-               box-shadow:3px 3px 15px black!important;
-               webkit-box-shadow:3px 3px 15px black!important;
-           }
-           
-           #etsMCContainer{
-               box-shadow:0px 0px 20px 1px!important;
-           }
-           `
+          #etsBellowHeader {
+            background-image: url(${chrome.runtime.getURL('assets/pavillonE.jpg')}), linear-gradient(to bottom, white, white) !important;
+            background-repeat: no-repeat;
+          }
+
+          #etsHeaderContainer{
+            background-color: #262626 !important;
+            box-shadow: 3px 3px 15px black !important;
+            webkit-box-shadow: 3px 3px 15px black !important;
+          }
+
+          #etsMCContainer{
+            box-shadow: 0px 0px 20px 1px!important;
+          }`
         );
     }
 });


### PR DESCRIPTION
Le thème Pavillion E se répète sur certain browser car il manque la règle `background-repeat: no-repeat;`.

Cette PR ajoute la règle manquante et enlève des sélecteurs superflus qui ralentissaient le browser car l'image était chargée trois fois plutôt qu'une.